### PR TITLE
Select resources by name or url (if ID fails)

### DIFF
--- a/pkg/selection/cacertificate.go
+++ b/pkg/selection/cacertificate.go
@@ -35,7 +35,7 @@ func MustSelectCACertificate(ctx context.Context, log zerolog.Logger, id, projec
 	}
 	result, err := cryptoc.GetCACertificate(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup CA certificate by name or URL
 			project := MustSelectProject(ctx, log, projectID, orgID, rmc)
 			list, err := cryptoc.ListCACertificates(ctx, &common.ListOptions{ContextId: project.GetId()})

--- a/pkg/selection/deployment.go
+++ b/pkg/selection/deployment.go
@@ -35,7 +35,7 @@ func MustSelectDeployment(ctx context.Context, log zerolog.Logger, id, projectID
 	}
 	result, err := datac.GetDeployment(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup deployment by name or URL
 			project := MustSelectProject(ctx, log, projectID, orgID, rmc)
 			list, err := datac.ListDeployments(ctx, &common.ListOptions{ContextId: project.GetId()})

--- a/pkg/selection/group.go
+++ b/pkg/selection/group.go
@@ -35,7 +35,7 @@ func MustSelectGroup(ctx context.Context, log zerolog.Logger, id, orgID string, 
 	}
 	result, err := iamc.GetGroup(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup group by name or URL
 			org := MustSelectOrganization(ctx, log, orgID, rmc)
 			list, err := iamc.ListGroups(ctx, &common.ListOptions{ContextId: org.GetId()})

--- a/pkg/selection/organization.go
+++ b/pkg/selection/organization.go
@@ -33,7 +33,7 @@ func MustSelectOrganization(ctx context.Context, log zerolog.Logger, id string, 
 	}
 	result, err := rmc.GetOrganization(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup organization by name or URL
 			list, err := rmc.ListOrganizations(ctx, &common.ListOptions{})
 			if err == nil {

--- a/pkg/selection/organization_invite.go
+++ b/pkg/selection/organization_invite.go
@@ -34,7 +34,7 @@ func MustSelectOrganizationInvite(ctx context.Context, log zerolog.Logger, id, o
 	}
 	result, err := rmc.GetOrganizationInvite(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup organization invite by name or URL
 			org := MustSelectOrganization(ctx, log, orgID, rmc)
 			list, err := rmc.ListOrganizationInvites(ctx, &common.ListOptions{ContextId: org.GetId()})

--- a/pkg/selection/project.go
+++ b/pkg/selection/project.go
@@ -34,7 +34,7 @@ func MustSelectProject(ctx context.Context, log zerolog.Logger, id, orgID string
 	}
 	result, err := rmc.GetProject(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup project by name or URL
 			org := MustSelectOrganization(ctx, log, orgID, rmc)
 			list, err := rmc.ListProjects(ctx, &common.ListOptions{ContextId: org.GetId()})

--- a/pkg/selection/provider.go
+++ b/pkg/selection/provider.go
@@ -33,7 +33,7 @@ func MustSelectProvider(ctx context.Context, log zerolog.Logger, id string, plat
 	}
 	result, err := platformc.GetProvider(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup provider by name or URL
 			list, err := platformc.ListProviders(ctx, &common.ListOptions{})
 			if err == nil {

--- a/pkg/selection/region.go
+++ b/pkg/selection/region.go
@@ -34,7 +34,7 @@ func MustSelectRegion(ctx context.Context, log zerolog.Logger, id, providerID st
 	}
 	result, err := platformc.GetRegion(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup region by name or URL
 			provider := MustSelectProvider(ctx, log, providerID, platformc)
 			list, err := platformc.ListRegions(ctx, &common.ListOptions{ContextId: provider.GetId()})

--- a/pkg/selection/role.go
+++ b/pkg/selection/role.go
@@ -35,7 +35,7 @@ func MustSelectRole(ctx context.Context, log zerolog.Logger, id, orgID string, i
 	}
 	result, err := iamc.GetRole(ctx, &common.IDOptions{Id: id})
 	if err != nil {
-		if common.IsNotFound(err) || common.IsPermissionDenied(err) {
+		if common.IsNotFound(err) {
 			// Try to lookup role by name or URL
 			org := MustSelectOrganization(ctx, log, orgID, rmc)
 			list, err := iamc.ListRoles(ctx, &common.ListOptions{ContextId: org.GetId()})


### PR DESCRIPTION
This PR extends #18 

This PR improves usability of the CLI.

It is now allowed to pass a name or URL of a result instead of the requested ID.