### PR TITLE
OAS-2081 | Added rotate deployment server command

### DIFF
--- a/apis.json
+++ b/apis.json
@@ -1,7 +1,7 @@
 {
   "backup/v1": "1.2.0",
   "crypto/v1": "1.3.1",
-  "data/v1": "2.0.0",
+  "data/v1": "2.1.0",
   "example/v1": "1.2.0",
   "iam/v1": "1.0.0",
   "monitoring/v1": "1.3.0",

--- a/cmd/data/get_server_status.go
+++ b/cmd/data/get_server_status.go
@@ -58,6 +58,7 @@ func init() {
 				log := cmd.CLILog
 				deploymentID, argsUsed := cmd.OptOption("deployment-id", cargs.deploymentID, args, 0)
 				cmd.MustCheckNumberOfArgs(args, argsUsed)
+				log.Info().Msgf("Got deployment id %s", deploymentID)
 
 				// Connect
 				conn := cmd.MustDialAPI()

--- a/cmd/data/get_server_status.go
+++ b/cmd/data/get_server_status.go
@@ -58,7 +58,6 @@ func init() {
 				log := cmd.CLILog
 				deploymentID, argsUsed := cmd.OptOption("deployment-id", cargs.deploymentID, args, 0)
 				cmd.MustCheckNumberOfArgs(args, argsUsed)
-				log.Info().Msgf("Got deployment id %s", deploymentID)
 
 				// Connect
 				conn := cmd.MustDialAPI()

--- a/cmd/data/rotate_deployment_server.go
+++ b/cmd/data/rotate_deployment_server.go
@@ -1,0 +1,79 @@
+//
+// DISCLAIMER
+//
+// Copyright 2021 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package data
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	data "github.com/arangodb-managed/apis/data/v1"
+
+	"github.com/arangodb-managed/oasisctl/cmd"
+)
+
+func init() {
+	cmd.InitCommand(
+		cmd.RotateDeploymentCmd,
+		&cobra.Command{
+			Use:   "server",
+			Short: "Rotate a single server of a deployment",
+		},
+		func(c *cobra.Command, f *flag.FlagSet) {
+			cargs := &struct {
+				serverID       string
+				deploymentID   string
+				organizationID string
+				projectID      string
+			}{}
+			f.StringVarP(&cargs.serverID, "server-id", "s", cmd.DefaultServer(), "Identifier of the deployment server")
+			f.StringVarP(&cargs.deploymentID, "deployment-id", "d", cmd.DefaultDeployment(), "Identifier of the deployment")
+			f.StringVarP(&cargs.organizationID, "organization-id", "o", cmd.DefaultOrganization(), "Identifier of the organization")
+			f.StringVarP(&cargs.projectID, "project-id", "p", cmd.DefaultProject(), "Identifier of the project")
+
+			c.Run = func(c *cobra.Command, args []string) {
+				// Validate arguments
+				log := cmd.CLILog
+				deploymentID, argsUsed := cmd.OptOption("deployment-id", cargs.deploymentID, args, 0)
+				serverID, argsUsed := cmd.OptOption("deployment-id", cargs.deploymentID, args, argsUsed)
+				cmd.MustCheckNumberOfArgs(args, argsUsed)
+
+				// Connect
+				conn := cmd.MustDialAPI()
+				datac := data.NewDataServiceClient(conn)
+				ctx := cmd.ContextWithToken()
+
+				// Request server rotation
+				if _, err := datac.RotateDeploymentServer(ctx, &data.RotateDeploymentServerRequest{
+					DeploymentId: deploymentID,
+					ServerId:     serverID,
+				}); err != nil {
+					log.Fatal().Err(err).Msg("Failed to rotate server.")
+				}
+
+				fmt.Println("Server rotation has been requested.")
+			}
+		},
+	)
+}

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -67,3 +67,6 @@ func DefaultURL() string { return envOrDefault("URL", "") }
 
 // DefaultPluginHandler returns the default value for a URL
 func DefaultPluginHandler() string { return envOrDefault("PLUGIN_HANDLER", "") }
+
+// DefaultServer returns the default value for a deployment server identifier
+func DefaultServer() string { return envOrDefault("SERVER", "") }

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -23,6 +23,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/arangodb-managed/oasisctl/pkg/format"
 )
 
@@ -70,3 +72,12 @@ func DefaultPluginHandler() string { return envOrDefault("PLUGIN_HANDLER", "") }
 
 // DefaultServer returns the default value for a deployment server identifier
 func DefaultServer() string { return envOrDefault("SERVER", "") }
+
+// SplitByComma splits the given input around ',', returning an empty
+// slice (nil) if the input is empty.
+func SplitByComma(input string) []string {
+	if input == "" {
+		return nil
+	}
+	return strings.Split(input, ",")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -198,7 +198,7 @@ func MustDialAPI(opts ...MustDialOption) *grpc.ClientConn {
 			CLILog.Fatal().Err(err).Msg("Failed to call compatibility checker.")
 		}
 		if !resp.GetIsCompatible() {
-			CLILog.Fatal().Str("current_version", currentVersion.String()).Msg("This tool is not compatible with the current API. Please upgrade.")
+			CLILog.Warn().Str("current_version", currentVersion.String()).Msg("This tool is not compatible with the current API. Please upgrade.")
 		}
 	}
 	return conn
@@ -236,6 +236,18 @@ func OptOption(key, value string, args []string, argIndex int) (string, int) {
 		return args[argIndex], argIndex + 1
 	}
 	return "", 0
+}
+
+// OptOptionSlice returns given slice value if not empty.
+// Returns: option-value, number-of-args-used(0|argIndex+1)
+func OptOptionSlice(key string, value []string, args []string, argIndex int) ([]string, int) {
+	if len(value) > 0 {
+		return value, 0
+	}
+	if len(args) > argIndex {
+		return args[argIndex:], len(args)
+	}
+	return nil, 0
 }
 
 // MustCheckNumberOfArgs compares the number of arguments with the expected

--- a/cmd/rotate.go
+++ b/cmd/rotate.go
@@ -1,0 +1,40 @@
+//
+// DISCLAIMER
+//
+// Copyright 2021 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	// RotateCmd is root for various `rotate ...` commands
+	RotateCmd = &cobra.Command{
+		Use:   "rotate",
+		Short: "Rotate resources",
+		Run:   ShowUsage,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(RotateCmd)
+}

--- a/cmd/rotate_deployment.go
+++ b/cmd/rotate_deployment.go
@@ -1,0 +1,40 @@
+//
+// DISCLAIMER
+//
+// Copyright 2021 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	// RotateDeploymentCmd is root for various `rotate deployment ...` commands
+	RotateDeploymentCmd = &cobra.Command{
+		Use:   "deployment",
+		Short: "Rotate deployment resources",
+		Run:   ShowUsage,
+	}
+)
+
+func init() {
+	RotateCmd.AddCommand(RotateDeploymentCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/golang/lint => golang.org/x/lint v0.0.0-20181026193005-c67002
 
 require (
 	github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1
-	github.com/arangodb-managed/apis v0.53.0
+	github.com/arangodb-managed/apis v0.54.0
 	github.com/arangodb-managed/arangocopy v0.0.0-20200728084932-9e3a6c61cf22
 	github.com/coreos/go-semver v0.3.0
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 h1:TEBmxO80TM04L8IuMWk77SGL1HomBmKTdzdJLLWznxI=
 github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
-github.com/arangodb-managed/apis v0.53.0 h1:72QZ7dWK32hbJAYr3AN1nU8m3oSZwlyuqfMat0BpWP8=
-github.com/arangodb-managed/apis v0.53.0/go.mod h1:dSEV+DTPdZNH06qVqFWA+F0OcaL2ePGEo+odyMaU72Y=
+github.com/arangodb-managed/apis v0.54.0 h1:stV/Emk545OiX01GuM9wB8INAkqzErFNAo0F2x+02X8=
+github.com/arangodb-managed/apis v0.54.0/go.mod h1:dSEV+DTPdZNH06qVqFWA+F0OcaL2ePGEo+odyMaU72Y=
 github.com/arangodb-managed/arangocopy v0.0.0-20200728084932-9e3a6c61cf22 h1:AO6iKTfLb3ij5D6cZ3ueHrQbNh8u/QEHbIace8JzDkI=
 github.com/arangodb-managed/arangocopy v0.0.0-20200728084932-9e3a6c61cf22/go.mod h1:Yv//aCZvU4/H0giMMNP+tEP9HCJZ8HzfmsH1Am36RLs=
 github.com/arangodb/go-driver v0.0.0-20200529120925-bf58c3c102b4 h1:wtMkIS/neOMpJUjFhIjLx1cN026s4t79KF0hLVMSANs=

--- a/pkg/selection/deployment.go
+++ b/pkg/selection/deployment.go
@@ -68,6 +68,7 @@ func SelectDeployment(ctx context.Context, log zerolog.Logger, id, projectID, or
 	result, err := datac.GetDeployment(ctx, &common.IDOptions{Id: id})
 	if err != nil {
 		if common.IsNotFound(err) {
+			log.Debug().Msg("Deployment not found")
 			// Try to lookup deployment by name or URL
 			project, err := SelectProject(ctx, log, projectID, orgID, rmc)
 			if err != nil {


### PR DESCRIPTION
For example (using oasisctl-dev plugin)
```
$ ./bin/darwin/amd64/oasisctl dev rotate deployment server  a9lirb6dasghsesg6s13 AGNT-v49uwsyp CRDN-txznyjh7 AGNT-d5xxiycx
Server rotation has been requested for server 'AGNT-v49uwsyp'.
Server rotation has been requested for server 'CRDN-txznyjh7'.
Server rotation has been requested for server 'AGNT-d5xxiycx'.
```