### PR TITLE
Indent code examples in long description of completion command

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -34,13 +34,13 @@ var (
 		Use:   "completion",
 		Short: "Generates bash completion scripts",
 		Long: `To load completion run
-	
-. <(oasisctl completion [bash|fish|powershell|zsh])
-	
+
+    . <(oasisctl completion [bash|fish|powershell|zsh])
+
 To configure your bash shell to load completions for each session add to your bashrc
-	
-# ~/.bashrc or ~/.profile
-. <(oasisctl completion bash)
+
+    # ~/.bashrc or ~/.profile
+    . <(oasisctl completion bash)
 `,
 		ValidArgs: []string{"", "bash", "fish", "powershell", "zsh"},
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This fixes a Markdown rendering issue in the [documentation](https://main--zealous-morse-14392b.netlify.app/docs/3.8/oasis/oasisctl-completion.html):

![image](https://user-images.githubusercontent.com/7819991/150778871-e4a1a91c-f6b0-4ed5-99ef-4a58e2a41a08.png)

Using four spaces turns it into Markdown code blocks for the docs but should also be acceptable for display on command-line:

```
> oasisctl completion --help
To load completion run

    . <(oasisctl completion [bash|fish|powershell|zsh])

To configure your bash shell to load completions for each session add to your bashrc

    # ~/.bashrc or ~/.profile
    . <(oasisctl completion bash)

Usage:
  oasisctl completion [flags]

Flags:
  -h, --help   help for completion

Global Flags:
      --endpoint string   API endpoint of the ArangoDB Oasis (default "api.cloud.arangodb.com")
      --format string     Output format (table|json) (default "table")
      --token string      Token used to authenticate at ArangoDB Oasis
```