### PR TITLE
feature/OAS-9630-Show-notebook-disk-size

### DIFF
--- a/pkg/format/notebook.go
+++ b/pkg/format/notebook.go
@@ -39,6 +39,7 @@ func Notebook(x *notebook.Notebook, opts Options) string {
 		kv{"deleted-at", formatTime(opts, x.GetDeletedAt(), "-")},
 		kv{"phase", x.GetStatus().GetPhase()},
 		kv{"endpoint", x.GetStatus().GetEndpoint()},
+		kv{"disk-size", fmt.Sprintf("%d%s", x.GetModel().GetDiskSize(), "GiB")},
 	)
 }
 
@@ -55,6 +56,7 @@ func NotebookList(list []*notebook.Notebook, opts Options) string {
 			{"phase", x.GetStatus().GetPhase()},
 			{"paused", formatBool(opts, x.GetIsPaused())},
 			{"created-at", formatTime(opts, x.GetCreatedAt())},
+			{"disk-size", fmt.Sprintf("%d%s", x.GetModel().GetDiskSize(), "GiB")},
 		}
 	}, false)
 }


### PR DESCRIPTION
OAS-9630 | Show the notebook(s) disk size when using get/list